### PR TITLE
feat: add shared types and aliases

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
     "package": "electron-builder --win"
   },
   "dependencies": {
+    "@gw2-mcp/shared": "workspace:*",
     "electron": "^30.0.0",
     "keytar": "^7.9.0"
   },

--- a/apps/desktop/tsconfig.json
+++ b/apps/desktop/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "module": "commonjs"
+    "module": "commonjs",
+    "baseUrl": ".",
+    "paths": {
+      "@gw2-mcp/shared": ["../../packages/shared/src"]
+    }
   },
   "include": ["src/**/*"]
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -3,7 +3,7 @@ import swagger from '@fastify/swagger';
 import swaggerUi from '@fastify/swagger-ui';
 import dotenv from 'dotenv';
 import { fetch } from 'undici';
-import { JsonRpcRequest } from '@gw2-mcp/shared';
+import { McpRequest, McpResponse } from '@gw2-mcp/shared';
 
 dotenv.config();
 
@@ -16,12 +16,12 @@ app.register(swagger, {
 });
 app.register(swaggerUi, { routePrefix: '/docs' });
 
-app.post('/mcp', async (request) => {
-  const body = request.body as JsonRpcRequest;
+app.post('/mcp', async (request): Promise<McpResponse> => {
+  const body = request.body as McpRequest;
   if (body.method === 'ping') {
-    return { jsonrpc: '2.0', result: 'pong', id: body.id ?? null };
+    return { id: body.id, result: 'pong' };
   }
-  return { jsonrpc: '2.0', error: { code: -32601, message: 'Method not found' }, id: body.id ?? null };
+  return { id: body.id, error: { code: -32601, message: 'Method not found' } };
 });
 
 app.get('/api/status', async () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,13 +1,28 @@
-export interface JsonRpcRequest {
-  jsonrpc: '2.0';
-  method: string;
-  params?: unknown;
-  id?: string | number | null;
-}
+export type McpRequest = { id: string; method: string; params?: unknown };
+export type McpResponse = { id: string; result?: unknown; error?: { code: number; message: string } };
 
-export interface StatusResponse {
-  ok: boolean;
-  build: number;
-}
+export type StatusResponse = { hasApiKey: boolean; server: "running"|"stopped"; port: number };
+export type SetGw2KeyRequest = { key: string };
 
-export const TOOL_NAME = 'GW2 MCP';
+export type PriceDto = { itemId: number; buy: number; sell: number; asOfUtc: string };
+export type InventorySnapshotDto = {
+  materials: Record<number, number>;
+  bank: Record<number, number>;
+  characterTotals: Record<number, number>;
+  wallet: Record<string, number>;
+};
+
+export const ToolNames = {
+  GetStatus: "gw2.getStatus",
+  SetApiKey: "gw2.setApiKey",
+  DeleteApiKey: "gw2.deleteApiKey",
+  ItemsGet: "gw2.items.get",
+  ItemsSearchByName: "gw2.items.searchByName",
+  RecipesGet: "gw2.recipes.get",
+  RecipesSearchByOutputItemId: "gw2.recipes.searchByOutputItemId",
+  PricesGet: "gw2.prices.get",
+  AccountMaterials: "gw2.account.getMaterials",
+  AccountBank: "gw2.account.getBank",
+  AccountCharacters: "gw2.account.getCharacters",
+  AccountWallet: "gw2.account.getWallet",
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@gw2-mcp/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       electron:
         specifier: ^30.0.0
         version: 30.5.1


### PR DESCRIPTION
## Summary
- add shared MCP request/response and dto types
- use new types in server
- configure shared package alias for desktop

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b47a538b30832fa7e04e071edcb287