### PR TITLE
feat: centralize gw2 key storage on server

### DIFF
--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -12,10 +12,7 @@ export default defineConfig({
       outDir: 'dist',
       sourcemap: true,
       rollupOptions: {
-        external: [
-          // ensure native addon loads at runtime from node_modules
-          'keytar',
-        ],
+        external: [],
       },
     },
   },
@@ -30,9 +27,7 @@ export default defineConfig({
       emptyOutDir: false,
       sourcemap: true,
       rollupOptions: {
-        external: [
-          'keytar',
-        ],
+        external: [],
       },
     },
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,8 +9,7 @@
     "package": "electron-builder --win"
   },
   "dependencies": {
-    "@gw2-mcp/shared": "workspace:*",
-    "keytar": "^7.9.0"
+    "@gw2-mcp/shared": "workspace:*"
   },
   "devDependencies": {
     "electron": "^30.0.0",

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -1,6 +1,5 @@
 import { app, BrowserWindow, Tray, Menu, ipcMain, nativeImage, shell, clipboard } from 'electron';
 import path from 'path';
-import keytar from 'keytar';
 // Defer resolving the server builder so dev can run independently.
 let buildServer: undefined | (() => { start: () => Promise<any>; stop: () => Promise<any> });
 function resolveServerBuilder() {
@@ -17,9 +16,6 @@ let tray: Tray | null = null;
 let win: BrowserWindow | null = null;
 let serverCtrl: ReturnType<NonNullable<typeof buildServer>> | null = null;
 let isQuitting = false;
-
-const SERVICE = 'GW2Mcp';
-const ACCOUNT = 'GW2_API_KEY';
 const ENDPOINT = 'http://127.0.0.1:5123/mcp';
 const DOCS = 'http://127.0.0.1:5123/docs';
 
@@ -70,11 +66,6 @@ async function stopServer() {
   serverCtrl = null;
 }
 
-async function getStatus() {
-  const key = await keytar.getPassword(SERVICE, ACCOUNT);
-  return { key: !!key, server: !!serverCtrl };
-}
-
 app.whenReady().then(() => {
   createWindow();
   tray = new Tray(nativeImage.createEmpty());
@@ -90,16 +81,6 @@ app.whenReady().then(() => {
 });
 app.on('before-quit', () => {
   isQuitting = true;
-});
-
-ipcMain.handle('get-status', getStatus);
-ipcMain.handle('set-api-key', async (_e, key: string) => {
-  await keytar.setPassword(SERVICE, ACCOUNT, key);
-  return true;
-});
-ipcMain.handle('delete-api-key', async () => {
-  await keytar.deletePassword(SERVICE, ACCOUNT);
-  return true;
 });
 ipcMain.handle('start-server', () => startServer());
 ipcMain.handle('stop-server', () => stopServer());

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -1,10 +1,32 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
+async function getStatus() {
+  try {
+    const res = await fetch('http://127.0.0.1:5123/api/status');
+    const json = await res.json();
+    return { key: json.hasApiKey, server: true };
+  } catch {
+    return { key: false, server: false };
+  }
+}
+
+async function setApiKey(key: string) {
+  await fetch('http://127.0.0.1:5123/api/settings/gw2key', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ key }),
+  });
+}
+
+async function deleteApiKey() {
+  await fetch('http://127.0.0.1:5123/api/settings/gw2key', { method: 'DELETE' });
+}
+
 contextBridge.exposeInMainWorld('api', {
-  getStatus: () => ipcRenderer.invoke('get-status'),
-  setApiKey: (key: string) => ipcRenderer.invoke('set-api-key', key),
-  deleteApiKey: () => ipcRenderer.invoke('delete-api-key'),
+  getStatus,
+  setApiKey,
+  deleteApiKey,
   startServer: () => ipcRenderer.invoke('start-server'),
   stopServer: () => ipcRenderer.invoke('stop-server'),
-  copyEndpoint: () => ipcRenderer.invoke('copy-endpoint')
+  copyEndpoint: () => ipcRenderer.invoke('copy-endpoint'),
 });

--- a/apps/server/src/gw2/index.ts
+++ b/apps/server/src/gw2/index.ts
@@ -1,23 +1,7 @@
 import { fetch } from 'undici';
+import { getApiKey, setApiKey, deleteApiKey, hasApiKey, SERVICE, ACCOUNT } from './secret';
 
-let keytar: typeof import('keytar');
-try {
-  keytar = require('keytar');
-} catch {
-  const store = new Map<string, string>();
-  keytar = {
-    async getPassword(service: string, account: string) {
-      return store.get(`${service}:${account}`) ?? null;
-    },
-    async setPassword(service: string, account: string, password: string) {
-      store.set(`${service}:${account}`, password);
-      return true;
-    },
-    async deletePassword(service: string, account: string) {
-      return store.delete(`${service}:${account}`);
-    },
-  } as any;
-}
+export { getApiKey, setApiKey, deleteApiKey, hasApiKey, SERVICE, ACCOUNT };
 
 const BASE = 'https://api.guildwars2.com';
 
@@ -85,7 +69,7 @@ export class Gw2Public {
 }
 
 async function authHeaders(): Promise<Record<string, string>> {
-  const key = await keytar.getPassword('GW2Mcp', 'GW2_API_KEY');
+  const key = await getApiKey();
   if (!key) {
     throw new Error('GW2 API key not set');
   }
@@ -105,17 +89,4 @@ export class Gw2Account {
   async wallet(): Promise<unknown> {
     return request('/v2/account/wallet', await authHeaders());
   }
-}
-
-export async function hasApiKey(): Promise<boolean> {
-  const key = await keytar.getPassword('GW2Mcp', 'GW2_API_KEY');
-  return !!key;
-}
-
-export async function setApiKey(key: string): Promise<void> {
-  await keytar.setPassword('GW2Mcp', 'GW2_API_KEY', key);
-}
-
-export async function deleteApiKey(): Promise<void> {
-  await keytar.deletePassword('GW2Mcp', 'GW2_API_KEY');
 }

--- a/apps/server/src/gw2/secret.ts
+++ b/apps/server/src/gw2/secret.ts
@@ -1,0 +1,46 @@
+import keytar from 'keytar';
+
+export const SERVICE = 'GW2Mcp';
+export const ACCOUNT = 'GW2_API_KEY';
+
+function mask(key: string): string {
+  if (key.length <= 4) return '*'.repeat(key.length);
+  return `${key.slice(0, 2)}...${key.slice(-2)}`;
+}
+
+export async function setApiKey(key: string): Promise<void> {
+  try {
+    await keytar.setPassword(SERVICE, ACCOUNT, key);
+  } catch (err) {
+    console.warn({ key: mask(key) }, 'keytar setApiKey failed');
+    throw err;
+  }
+}
+
+export async function deleteApiKey(): Promise<void> {
+  try {
+    await keytar.deletePassword(SERVICE, ACCOUNT);
+  } catch (err) {
+    console.warn('keytar deleteApiKey failed');
+    throw err;
+  }
+}
+
+export async function hasApiKey(): Promise<boolean> {
+  try {
+    const key = await keytar.getPassword(SERVICE, ACCOUNT);
+    return !!key;
+  } catch (err) {
+    console.warn('keytar hasApiKey failed');
+    throw err;
+  }
+}
+
+export async function getApiKey(): Promise<string | null> {
+  try {
+    return await keytar.getPassword(SERVICE, ACCOUNT);
+  } catch (err) {
+    console.warn('keytar getApiKey failed');
+    throw err;
+  }
+}

--- a/apps/server/test/secret.spec.ts
+++ b/apps/server/test/secret.spec.ts
@@ -1,0 +1,21 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+async function importSecret() {
+  return await import('../src/gw2/secret');
+}
+
+test('key persistence flow', async () => {
+  let secret = await importSecret();
+  expect(await secret.hasApiKey()).toBe(false);
+  await secret.setApiKey('TEST-KEY-123');
+  expect(await secret.hasApiKey()).toBe(true);
+  vi.resetModules();
+  secret = await importSecret();
+  expect(await secret.hasApiKey()).toBe(true);
+  await secret.deleteApiKey();
+  expect(await secret.hasApiKey()).toBe(false);
+});

--- a/apps/server/test/setup.ts
+++ b/apps/server/test/setup.ts
@@ -1,0 +1,18 @@
+import { vi } from 'vitest';
+
+const store = new Map<string, string>();
+
+vi.mock('keytar', () => ({
+  default: {
+    async getPassword(service: string, account: string) {
+      return store.get(`${service}:${account}`) ?? null;
+    },
+    async setPassword(service: string, account: string, password: string) {
+      store.set(`${service}:${account}`, password);
+    },
+    async deletePassword(service: string, account: string) {
+      store.delete(`${service}:${account}`);
+      return true;
+    },
+  },
+}));

--- a/apps/server/test/status.spec.ts
+++ b/apps/server/test/status.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test, beforeAll, afterAll, vi } from 'vitest';
+import { buildServer } from '../src/index';
+
+let app: ReturnType<typeof buildServer>;
+
+beforeAll(async () => {
+  app = buildServer();
+  await app.ready();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+test('status reflects key presence', async () => {
+  let res = await app.inject({ method: 'GET', url: '/api/status' });
+  expect(res.json().hasApiKey).toBe(false);
+  await app.inject({
+    method: 'POST',
+    url: '/api/settings/gw2key',
+    payload: { key: 'TEST-KEY-123' },
+  });
+  res = await app.inject({ method: 'GET', url: '/api/status' });
+  expect(res.json().hasApiKey).toBe(true);
+  await app.inject({ method: 'DELETE', url: '/api/settings/gw2key' });
+  res = await app.inject({ method: 'GET', url: '/api/status' });
+  expect(res.json().hasApiKey).toBe(false);
+});

--- a/apps/server/vitest.config.ts
+++ b/apps/server/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
+    setupFiles: ['./test/setup.ts'],
   },
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "pnpm -C apps/server test",
     "smoke:mcp": "pnpm -C apps/server smoke:mcp",
     "smoke:mcp-get-vs-post": "pnpm -C apps/server smoke:mcp-get-vs-post",
-    "smoke:port": "tsx scripts/smoke/port-ownership.ts"
+    "smoke:port": "tsx scripts/smoke/port-ownership.ts",
+    "smoke:key": "tsx scripts/smoke/key-persist.ts"
   },
   "devDependencies": {
     "typescript": "^5.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       '@gw2-mcp/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-      keytar:
-        specifier: ^7.9.0
-        version: 7.9.0
     devDependencies:
       electron:
         specifier: ^30.0.0

--- a/scripts/smoke/key-persist.ts
+++ b/scripts/smoke/key-persist.ts
@@ -1,0 +1,40 @@
+import { request } from 'undici';
+import readline from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+
+async function postKey(key: string) {
+  await request('http://127.0.0.1:5123/api/settings/gw2key', {
+    method: 'POST',
+    body: JSON.stringify({ key }),
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+async function getStatus() {
+  const res = await request('http://127.0.0.1:5123/api/status');
+  const data = await res.body.json();
+  return data.hasApiKey as boolean;
+}
+
+async function deleteKey() {
+  await request('http://127.0.0.1:5123/api/settings/gw2key', { method: 'DELETE' });
+}
+
+(async () => {
+  await postKey('FAKE-PERSIST-KEY');
+  let present = await getStatus();
+  if (!present) throw new Error('Key not set');
+  console.log('Key set; please restart the server then press enter...');
+  const rl = readline.createInterface({ input, output });
+  await rl.question('');
+  present = await getStatus();
+  if (!present) throw new Error('Key missing after restart');
+  await deleteKey();
+  present = await getStatus();
+  if (present) throw new Error('Key still present after delete');
+  console.log('Key persistence smoke test passed');
+  rl.close();
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tmp-inspect-keytar.js
+++ b/tmp-inspect-keytar.js
@@ -1,1 +1,0 @@
-const m=require('./apps/desktop/dist/chunks/keytar-Do4Vvvyw.node'); console.log('keys', Object.keys(m)); console.log('types', typeof m.getPassword, typeof m.setPassword);


### PR DESCRIPTION
## Summary
- move key storage into server-only secret module and expose presence endpoints
- remove Electron keytar usage; UI uses server HTTP for key management
- add diagnostics, logger redaction, persistence tests and smoke script

## Testing
- `pnpm -C apps/server test`
- `NODE_OPTIONS="--require $(pwd)/apps/server/test/stub.cjs" pnpm --filter @gw2-mcp/server exec tsx test/debug-secret.ts` *(debug secret example)*

------
https://chatgpt.com/codex/tasks/task_e_68b4c6004bc4832f936ad8d9d0c6ad78